### PR TITLE
Patch the infinity coin glitch

### DIFF
--- a/Houdini/Handlers/Games/__init__.py
+++ b/Houdini/Handlers/Games/__init__.py
@@ -38,7 +38,8 @@ def determineCoinsOverdose(self, score):
 def handleSendGameOver(self, data):
     if self.waddle or self.table:
         return
-
+    if self.room.Id == 901:
+            return
     if self.room.isGame:
         if determineCoinsOverdose(self, data.Score):
             return cheatBan(self, self.user.ID, comment="Coin cheat detected")


### PR DESCRIPTION
It happens when you open a game from your igloo and keep getting infinity coins when you end the game. When doing it from a game, I noticed it kept going to a room 901 instead of an igloo room id so I just checked if it's equal. If anyone tries to end the game and tries to keep getting the coins, they will get stuck.